### PR TITLE
Remove unused regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 byteorder = "1.4.3"
 thiserror = "1.0.25"
 bytesize = "1.0.1"
-regex = "1"
 
 [dev-dependencies]
 anyhow = "1.0.41"


### PR DESCRIPTION
It appears that the `regex` dependency is unused so this PR removes it from `Cargo.toml`.